### PR TITLE
Fixed fallback to local replays after external

### DIFF
--- a/src/CustomTypes/ReplayMenu.cpp
+++ b/src/CustomTypes/ReplayMenu.cpp
@@ -36,7 +36,7 @@ const std::vector<std::string> dropdownStrings = {
 };
 
 void OnReplayButtonClick() {
-    if(!usingLocalReplays)
+    if(usingLocalReplays)
         Manager::RefreshLevelReplays();
     Menu::PresentMenu();
 }

--- a/src/ReplayManager.cpp
+++ b/src/ReplayManager.cpp
@@ -254,6 +254,7 @@ namespace Manager {
     
     bool replaying = false;
     bool paused = false;
+    bool externalReplays = false;
     ReplayWrapper currentReplay;
     IDifficultyBeatmap* beatmap = nullptr;
 
@@ -262,12 +263,17 @@ namespace Manager {
     }
 
     void SetLevel(IDifficultyBeatmap* level) {
+        
+        if (!externalReplays || (beatmap != NULL && beatmap != level)) {
+            beatmap = level;
+            RefreshLevelReplays();
+        }
         beatmap = level;
-        RefreshLevelReplays();
     }
 
     void SetReplays(std::unordered_map<std::string, ReplayWrapper> replays, bool external) {
         currentReplays = replays;
+        externalReplays = external;
         if(currentReplays.size() > 0) {
             if(!external)
                 Menu::SetButtonEnabled(true);


### PR DESCRIPTION
- Added check for bools before the refreshing replay list, so external replays can be viewed multiple times from the menu